### PR TITLE
chore: export model after fixing bug in RAVEN

### DIFF
--- a/ComplementaryScripts/reconstructionProtocol.m
+++ b/ComplementaryScripts/reconstructionProtocol.m
@@ -343,6 +343,7 @@ model.grRules(rhtoRxns);
 % polymorpha: Hanpo2_15704. We will therefore replace the current grRule
 % with the H. polymorpha gene:
 model = changeGrRules(model, 'y300009', 'Hanpo2_15704', true);
+model = deleteUnusedGenes(model);
 
 % Curate the model so it can support growth on methanol. Reactions required
 % for methanol assimilation:

--- a/ModelFiles/dependencies.txt
+++ b/ModelFiles/dependencies.txt
@@ -1,4 +1,4 @@
 MATLAB	9.3.0.713579 (R2017b)
 libSBML	5.18.0
-RAVEN_toolbox	commit 385f3d7
+RAVEN_toolbox	commit 4b88f0b
 COBRA_toolbox	unknown

--- a/ModelFiles/yml/hanpo-GEM.yml
+++ b/ModelFiles/yml/hanpo-GEM.yml
@@ -58766,9 +58766,6 @@
     - id: RHTO_00906
     - name: RHTO_00906
   - !!omap
-    - id: RHTO_03911
-    - name: RHTO_03911
-  - !!omap
     - id: RHTO_03915
     - name: RHTO_03915
   - !!omap


### PR DESCRIPTION
- exportModel previously failed to export grRules with '-' in gene name